### PR TITLE
Fix: Avoid body link false positives

### DIFF
--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -42,9 +42,10 @@ const dependencyLinks = (): HTMLElement[] => {
 
 // if no dependency dialog, let's pick out links in task descriptions...
 //
-// .PrimaryNavigationLink is a link to another entity in Asana
+// .ProsemirrorEditor .PrimaryNavigationLink is a link to another
+// entity in Asana inside the text editor window
 // .ProsemirrorEditor-link is a link to an outside site
-const bodyLinks = () => Array.from(document.querySelectorAll('.PrimaryNavigationLink,.ProsemirrorEditor-link'));
+const bodyLinks = () => Array.from(document.querySelectorAll('.ProsemirrorEditor .PrimaryNavigationLink, .ProsemirrorEditor-link'));
 
 const focusOnFirstTask = () => {
   console.log('trying to focus on first task');


### PR DESCRIPTION
Don't open up links to temporary pop-up windows (e.g., (task) deleted,
(task) added, (task) marked complete)