### PR TITLE
Don't transpose digits in the date field

### DIFF
--- a/src/shortcuts-for-asana.ts
+++ b/src/shortcuts-for-asana.ts
@@ -173,5 +173,6 @@ export const shortcutsKeyDownBeforeOthers = (e: KeyboardEvent) => {
     clickRefineSearchButton();
   } else if (e.ctrlKey && e.key === 't') {
     selectTaskTime();
+    e.preventDefault(); // don't transpose text
   }
 };


### PR DESCRIPTION
Turns out transposing the last digits of 2022 doesn't really reveal a
bug..